### PR TITLE
Memory allocation reduction in client.req()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,13 @@
-Riak (protocol buffers) Client for Go [![docs examples](https://sourcegraph.com/api/repos/github.com/philhofer/riakpb/.badges/docs-examples.png)](https://sourcegraph.com/github.com/philhofer/riakpb) [![dependencies](https://sourcegraph.com/api/repos/github.com/philhofer/riakpb/.badges/dependencies.png)](https://sourcegraph.com/github.com/philhofer/riakpb)
+Riak for Go [![docs examples](https://sourcegraph.com/api/repos/github.com/philhofer/riakpb/.badges/docs-examples.png)](https://sourcegraph.com/github.com/philhofer/riakpb) [![dependencies](https://sourcegraph.com/api/repos/github.com/philhofer/riakpb/.badges/dependencies.png)](https://sourcegraph.com/github.com/philhofer/riakpb)
 ================
 
-A Riak client that doesn't use `interface{}`, but does use protocol buffers over
-raw TCP. 
+A Riak client designed for performance-critical Go programs.
+
+Complete documentation is at [godoc](http://godoc.org/github.com/philhofer/riakpb).
 
 ## Status
 
-Work in progress. Passes existing test cases.
-
-## Performance
-
-This client library was built with performance in mind.
-
-To run benchmarks, start up Riak locally and run:
-`go test -v -tags 'riak' -bench .`
-
-(You must be running the eLevelDB or memory backend with secondary
-indexes enabled.)
-
-Remember that TCP is a synchronous protocol, so using multiple
-TCP connections per node dramatically improves overall transaction
-throughput. In production, you would want to run *about* five live
-connections per node. (See: riakpb.Dial()) On my computer, I get 1300 writes and 2340 reads per second with one connection and 4000 writes and 7000 reads per second with 5 connections. Those numbers suggest that my computer would asymptotically approach 9000 writes and 14000 reads per second with an arbitrarily large number of connections. As always, you should benchmark on your production hardware with your specific use case. Remember, too, that Riak is specifically *not* optimized for the single-node case.
+Core functionality (fetch, store, secondary indexes, links) is complete, but many advanced features (MapReduce, Yokozuna search) are still on the way. There is no short-term guarantee that the API will remain stable. (We are shooting for a beta release in Nov. '14, followed by a "stable" 1.0 in December.) That being said, this code is already being actively tested in some production applications.
 
 ## Usage
 
@@ -79,14 +65,39 @@ err = blobs.Fetch(newBlob, myBlob.Info().Key())
 
 ```
 
-## Design
+## Performance
+
+This client library was built with performance in mind.
+
+To run benchmarks, start up Riak locally and run:
+`go test -v -tags 'riak' -bench .`
+
+(You must be running the eLevelDB or memory backend with secondary
+indexes enabled.)
+
+Remember that TCP is a synchronous protocol, so using multiple
+TCP connections per node dramatically improves overall transaction
+throughput. In production, you would want to run *about* five live
+connections per node. (See: riakpb.Dial()) On my computer, I get 1300 writes and 2340 reads per second with one connection and 4000 writes and 7000 reads per second with 5 connections. Those numbers suggest that my computer would asymptotically approach 9000 writes and 14000 reads per second with an arbitrarily large number of connections. As always, you should benchmark on your production hardware with your specific use case. Remember, too, that Riak is specifically *not* optimized for the single-node case.
+
+
+## Design & TODOs
 
 This package is focused on using Riak the way it was intended: with `allow_mult` set to `true`. This library will *always* use vclocks when getting and setting values. Additionally, this library adheres strictly to Riak's read-before-write policy.
 
 Internally, Return-Head is always set to `true`, so every Push() or Store() operation updates the local object's metadata. Consequently, you can carry out a series of transactions on an object in parallel, and avoid conflicts by using Push() (which enforces an If-Not-Modified precondition). You can retreive the latest version of an object by calling Update().
 
-The core "verbs" of this library (New, Fetch, Store, Push, Update, Delete) are meant to have intuitive and sane default behavior. For instance, New always asks Riak to abort the transaction if object already exists at the given key, and Update doesn't return the whole
+The core "verbs" of this library (New, Fetch, Store, Push, Update, Delete) are meant to have intuitive and sane default behavior. For instance, New always asks Riak to abort the transaction if an object already exists at the given key, and Update doesn't return the whole
 body of the object back from the database if it hasn't been modified.
 
-The Client object is designed to maintain many long-lived TCP connections to many different Riak nodes. It re-dials closed connections in the background. More TCP connections per client mean less contention for connections, at the cost of more system resources on both ends of the connection. Care should be taken to tune this parameter appropriately for your use case.
+The Client object is designed to maintain many long-lived TCP connections to many different Riak nodes. It re-dials closed connections in the background. More TCP connections per client mean less contention for connections, at the cost of more system resources on both ends of the connection. Care should be taken to tune this parameter appropriately for your use case. In the future we may allow for emphemeral connections. (We will need to find a way to do this without slowing down the existing `Client.ack()`.)
+
+Since garbage collection time bottlenecks many Go applications, a lot of effort was put into reducing memory allocations on database reads and writes. Much of the remaining improvement will have to come from carefully re-writing the `Marshal()` and `Unmarshal()` methods of the most frequently used protocol buffers messages. At the very least we may be able to reduce the total number of allocations by taking (better) advantage of `sync.Pool`. Right now we generate 774B (11 allocs) of garbage per read and 1022B (7 allocs) of garbage per write. (For comparison, an `http.Request` object is usually well over 1KB.)
+
+There is an open issue for cache buckets, which has the potential to dramatically improve performance in query-heavy (2i, map-reduce, Yokozuna) use cases. There are also some open issues related to implementing Riak 2.0 features.
+
+
+## License
+
+This code is MIT licensed. You may use it however you see fit. However, I would very much appreciate it if you create PRs in this repo for patches and improvements!
 

--- a/buf.go
+++ b/buf.go
@@ -1,0 +1,47 @@
+package riakpb
+
+import (
+	"sync"
+)
+
+var bufPool *sync.Pool
+
+func init() {
+	bufPool = new(sync.Pool)
+	bufPool.New = func() interface{} {
+		return new(buf)
+	}
+}
+
+type buf struct {
+	Body []byte
+}
+
+// proto message w/ Size and MarshalTo
+type protom interface {
+	MarshalTo([]byte) (n int, err error)
+	Size() int
+}
+
+func (b *buf) Set(p protom) error {
+	sz := p.Size()
+	var err error
+	if cap(b.Body) >= sz {
+		b.Body = b.Body[0:sz]
+		_, err = p.MarshalTo(b.Body)
+	} else {
+		b.Body = make([]byte, sz)
+		_, err = p.MarshalTo(b.Body)
+	}
+	return err
+}
+
+func getBuf() *buf {
+	b, ok := bufPool.Get().(*buf)
+	if !ok {
+		return new(buf)
+	}
+	return b
+}
+
+func putBuf(b *buf) { bufPool.Put(b) }

--- a/buf.go
+++ b/buf.go
@@ -37,11 +37,7 @@ func (b *buf) Set(p protom) error {
 }
 
 func getBuf() *buf {
-	b, ok := bufPool.Get().(*buf)
-	if !ok {
-		return new(buf)
-	}
-	return b
+	return bufPool.Get().(*buf)
 }
 
 func putBuf(b *buf) { bufPool.Put(b) }

--- a/buf.go
+++ b/buf.go
@@ -23,6 +23,7 @@ type protom interface {
 	Size() int
 }
 
+// opportunistic MarshalTo
 func (b *buf) Set(p protom) error {
 	sz := p.Size()
 	var err error

--- a/client.go
+++ b/client.go
@@ -403,20 +403,19 @@ exit:
 }
 
 func (c *Client) req(msg protom, code byte, res proto.Unmarshaler) (byte, error) {
-	buf := getBuf() // maybe we've already
+	buf := getBuf() // maybe we've already allocated
 	err := buf.Set(msg)
-	//bts, err := msg.Marshal()
 	if err != nil {
 		return 0, fmt.Errorf("riakpb: client.Req marshal err: %s", err)
 	}
 	resbts, rescode, err := c.doBuf(code, buf.Body)
+	buf.Body = resbts // save the largest-cap byte slice
 	if err != nil {
 		return 0, fmt.Errorf("riakpb: doBuf err: %s", err)
 	}
 	if rescode == 0 {
 		riakerr := new(rpbc.RpbErrorResp)
 		err = riakerr.Unmarshal(resbts)
-		//err = proto.Unmarshal(resbts, riakerr)
 		putBuf(buf)
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
BEFORE: 

Store: 1136B/op; 10 allocs/op
Fetch: 926B/op; 14 allocs/op

AFTER:

Store: 1023B/op; 8 allocs/op
Fetch: 775B/op; 11 allocs/op
