### PR TITLE
Handle siblings

### DIFF
--- a/client.go
+++ b/client.go
@@ -319,8 +319,7 @@ func (c *Client) err(n *node) {
 
 // writes the message to the node with
 // the appropriate leading message size
-// and the given message code, returning
-// the extended []byte
+// and the given message code
 func writeMsg(c *Client, n *node, msg []byte, code byte) error {
 	// bigendian length + code byte
 	var lead [5]byte
@@ -363,9 +362,8 @@ func readBody(c *Client, n *node, body []byte) error {
 	_, err := n.Read(body)
 	if err != nil {
 		n.Err()
-		return err
 	}
-	return nil
+	return err
 }
 
 // send the contents of a buffer and receive a response
@@ -389,7 +387,7 @@ func (c *Client) doBuf(code byte, msg []byte) ([]byte, byte, error) {
 	if err != nil {
 		return nil, code, err
 	}
-	if msglen == 0 { // no response body
+	if msglen == 0 {
 		msg = msg[0:0] // mark empty (necessary for ErrNotFound)
 		goto exit
 	}

--- a/fetch.go
+++ b/fetch.go
@@ -144,12 +144,12 @@ func (c *Client) Update(o Object, opts *ReadOpts) (bool, error) {
 	}
 	if len(res.GetContent()) > 1 {
 		if om, ok := o.(ObjectM); ok {
+			// like Fetch, we merge the results
+			// here and hope for reconciliation
+			// on write
 			om.Info().vclock = res.GetVclock()
 			err = handleMerge(om, res.Content)
-			if err != nil {
-				return false, err
-			}
-			return true, c.Store(om, nil)
+			return true, err
 		}
 		return false, handleMultiple(res.Content)
 	}

--- a/fetch.go
+++ b/fetch.go
@@ -90,6 +90,13 @@ func (c *Client) Fetch(o Object, bucket string, key string, opts *ReadOpts) erro
 		return ErrNotFound
 	}
 	if len(res.GetContent()) > 1 {
+		if om, ok := o.(ObjectM); ok {
+			err = handleMerge(om, res.Content)
+			if err != nil {
+				return err
+			}
+			return c.Store(om, nil)
+		}
 		return handleMultiple(res.Content)
 	}
 	err = readContent(o, res.GetContent()[0])
@@ -133,6 +140,13 @@ func (c *Client) Update(o Object, opts *ReadOpts) (bool, error) {
 		return false, ErrNotFound
 	}
 	if len(res.GetContent()) > 1 {
+		if om, ok := o.(ObjectM); ok {
+			err = handleMerge(om, res.Content)
+			if err != nil {
+				return false, err
+			}
+			return true, c.Store(om, nil)
+		}
 		return false, handleMultiple(res.Content)
 	}
 	err = readContent(o, res.Content[0])

--- a/fetch.go
+++ b/fetch.go
@@ -91,6 +91,9 @@ func (c *Client) Fetch(o Object, bucket string, key string, opts *ReadOpts) erro
 	}
 	if len(res.GetContent()) > 1 {
 		if om, ok := o.(ObjectM); ok {
+			om.Info().key = req.Key
+			om.Info().bucket = req.Bucket
+			om.Info().vclock = res.GetVclock()
 			err = handleMerge(om, res.Content)
 			if err != nil {
 				return err
@@ -141,6 +144,7 @@ func (c *Client) Update(o Object, opts *ReadOpts) (bool, error) {
 	}
 	if len(res.GetContent()) > 1 {
 		if om, ok := o.(ObjectM); ok {
+			om.Info().vclock = res.GetVclock()
 			err = handleMerge(om, res.Content)
 			if err != nil {
 				return false, err

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -23,6 +23,59 @@ func (t *TestObject) Marshal() ([]byte, error) {
 
 func (t *TestObject) Info() *Info { return t.info }
 
+func (t *TestObject) NewEmpty() ObjectM { return &TestObject{nil, &Info{}} }
+
+// naive merge
+func (t *TestObject) Merge(o ObjectM) {
+	tn := o.(*TestObject)
+	if len(tn.Data) > len(t.Data) {
+		t.Data = tn.Data
+	}
+}
+
+func TestMultipleVclocks(t *testing.T) {
+	oba := &TestObject{
+		Data: []byte("Body 1"),
+		info: &Info{},
+	}
+
+	obb := &TestObject{
+		Data: []byte("Body 2..."),
+		info: &Info{},
+	}
+
+	// manually create conflict - a user can't ordinarily do this
+	oba.Info().bucket, oba.Info().key = []byte("testbucket"), []byte("conflict")
+	obb.Info().bucket, obb.Info().key = []byte("testbucket"), []byte("conflict")
+
+	cl, err := DialOne("localhost:8087", "testClient")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = cl.Store(oba, nil)
+	if err != nil {
+		if _, ok := err.(*ErrMultipleResponses); !ok {
+			t.Fatal(err)
+		}
+	}
+	err = cl.Store(obb, nil)
+	if err == nil {
+		t.Error("Expected error; got nil")
+	}
+	if _, ok := err.(*ErrMultipleResponses); !ok {
+		t.Fatal(err)
+	}
+
+	obc := &TestObject{info: &Info{}}
+
+	// despite the conflict, this should not error
+	err = cl.Fetch(obc, "testbucket", "conflict", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestFetchNotFound(t *testing.T) {
 	cl, err := DialOne("localhost:8087", "testClient")
 	if err != nil {

--- a/fetch_test.go
+++ b/fetch_test.go
@@ -53,26 +53,28 @@ func TestMultipleVclocks(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The store operations should not error,
+	// because we are doing a fetch and merge
+	// when we detect multiple responses on
+	// Store()
+	err = cl.Store(obb, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	err = cl.Store(oba, nil)
 	if err != nil {
-		if _, ok := err.(*ErrMultipleResponses); !ok {
-			t.Fatal(err)
-		}
-	}
-	err = cl.Store(obb, nil)
-	if err == nil {
-		t.Error("Expected error; got nil")
-	}
-	if _, ok := err.(*ErrMultipleResponses); !ok {
 		t.Fatal(err)
 	}
 
-	obc := &TestObject{info: &Info{}}
-
-	// despite the conflict, this should not error
-	err = cl.Fetch(obc, "testbucket", "conflict", nil)
+	// Since our Merge() function takes the longer of the
+	// two Data fields, the body should always be "Body 2..."
+	err = cl.Fetch(oba, "testbucket", "conflict", nil)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if !bytes.Equal(oba.Data, []byte("Body 2...")) {
+		t.Errorf("Data should be %q; got %q", "Body 2...", oba.Data)
 	}
 }
 

--- a/object.go
+++ b/object.go
@@ -71,8 +71,10 @@ func handleMerge(om ObjectM, ct []*rpbc.RpbContent) error {
 			continue
 		}
 
+		// read into new empty
 		nom := om.NewEmpty()
-		err = readContent(om, ctt)
+		err = readContent(nom, ctt)
+		nom.Info().vclock = ctt.Vtag
 		if err != nil {
 			return err
 		}

--- a/object.go
+++ b/object.go
@@ -49,7 +49,7 @@ type ObjectM interface {
 	// Empty should return an initialized
 	// (zero-value) object of the same underlying
 	// type as the parent.
-	NewEmtpy() ObjectM
+	NewEmpty() ObjectM
 
 	// Merge should merge the argument object into the method receiver. It
 	// is safe to type-assert the argument of Merge to the same type
@@ -71,7 +71,7 @@ func handleMerge(om ObjectM, ct []*rpbc.RpbContent) error {
 			continue
 		}
 
-		nom := om.NewEmtpy()
+		nom := om.NewEmpty()
 		err = readContent(om, ctt)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR adds support for user-defined Merge() to be used to handle sibling objects.

Sibling conflicts aren't overwritten until a write operation (store/push) is called. I'm not sure this is optimal, although it reduces the chances that many clients attempt to resolve conflicts simultaneously.
