### PR TITLE
"In-use" tracking and proper Close()

### DIFF
--- a/client_norace.go
+++ b/client_norace.go
@@ -2,12 +2,16 @@
 
 package rkive
 
+import "sync/atomic"
+
 // finish node (success)
 func (c *Client) done(n *conn) {
 	n.Close()
+	atomic.AddInt32(&c.inuse, -1)
 }
 
 // finish node (err)
 func (c *Client) err(n *conn) {
 	n.Close()
+	atomic.AddInt32(&c.inuse, -1)
 }

--- a/client_race.go
+++ b/client_race.go
@@ -1,25 +1,29 @@
 // +build !race
-
 package rkive
+
+import "sync/atomic"
 
 // finish node (success)
 func (c *Client) done(n *conn) {
 	if c.closed() {
 		n.Close()
-		return
+	} else {
+		c.pool.Put(n)
 	}
-	c.pool.Put(n)
+	atomic.AddInt32(&c.inuse, -1)
 }
 
 // finish node (err)
 func (c *Client) err(n *conn) {
 	if c.closed() {
 		n.Close()
-		return
+	} else {
+		err := ping(n)
+		if err != nil {
+			n.Close()
+		} else {
+			c.pool.Put(n)
+		}
 	}
-	err := ping(n)
-	if err != nil {
-		n.Close()
-	}
-	c.pool.Put(n)
+	atomic.AddInt32(&c.inuse, -1)
 }

--- a/object_test.go
+++ b/object_test.go
@@ -2,7 +2,37 @@ package rkive
 
 import (
 	"testing"
+	"unsafe"
 )
+
+func TestClientAlignment(t *testing.T) {
+	// we're doing atomic operations
+	// on 'conns', 'inuse', and 'tag', so
+	// let's keep them 8-byte aligned
+
+	cl := Client{}
+
+	t.Logf("Client alignment: %d", unsafe.Alignof(cl))
+	if (unsafe.Alignof(cl) % 8) != 0 {
+		t.Errorf("Wanted 8-byte alignment; addr%8 = %d", unsafe.Alignof(cl)%8)
+	}
+
+	t.Logf("'conns' offset: %d", unsafe.Offsetof(cl.conns))
+	if (unsafe.Offsetof(cl.conns) % 8) != 0 {
+		t.Errorf("Wanted 8-byte alignment; addr%8 = %d", unsafe.Offsetof(cl.conns)%8)
+	}
+
+	t.Logf("'inuse' offset: %d", unsafe.Offsetof(cl.inuse))
+	if (unsafe.Offsetof(cl.inuse) % 8) != 0 {
+		t.Errorf("Wanted 8-byte alignment; addr%8 = %d", unsafe.Offsetof(cl.inuse)%8)
+	}
+
+	t.Logf("'tag' offset: %d", unsafe.Offsetof(cl.tag))
+	if (unsafe.Offsetof(cl.tag) % 8) != 0 {
+		t.Errorf("Wanted 8-byte alignment; addr%8 = %d", unsafe.Offsetof(cl.tag)%8)
+	}
+
+}
 
 func TestAddRemoveLink(t *testing.T) {
 	info := Info{}


### PR DESCRIPTION
Before, the `client.Close()` method could race under (unlikely) failure conditions. Now we keep track of the number of "in-use" connections and close after all of them have been returned.

(The worry in the previous implementation was that a call to `c.done` could, in principle, throw a nil pointer dereference on `c.pool` if the timing was inopportune.)

Also, `c.newconn` is a little smarter now; it runs through a random permutation of the address list on ever dial attempt, so we're guaranteed that every node is tried exactly once before it returns an error.

Also also, `c.tag`, `c.cons`, and `c.inuse` are `int32`s now, and there's a test to double-check that those fields are 8-byte aligned.
