### PR TITLE
MakeCache()

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Complete documentation is at [godoc](http://godoc.org/github.com/philhofer/rkive
 
 Core functionality (fetch, store, secondary indexes, links) is complete, but many advanced features (MapReduce, Yokozuna search) are still on the way. There is no short-term guarantee that the API will remain stable. (We are shooting for a beta release in Nov. '14, followed by a "stable" 1.0 in December.) That being said, this code is already being actively tested in some production applications.
 
+## Features
+
+ - Efficient connection pooling and re-dialing.
+ - Asynchronous batch fetches (see `FetchAsync` and `MultiFetchAsync`).
+ - Easy RAM-backed caching (see `MakeCache`).
+ - Transparent sibling conflict resolution.
+ - Compare-and-swap (see: `PushChangeset`).
+ - Low per-operation heap allocation overhead (5 alloc writes and 7 alloc reads).
+
+
 ## Usage
 
 Satisfy the `Object` interface and you're off to the races. The included 'Blob' object is the simplest possible Object implementation.

--- a/bucket.go
+++ b/bucket.go
@@ -62,6 +62,34 @@ func (b *Bucket) SetProperties(props *rpbc.RpbBucketProps) error {
 	return err
 }
 
+var (
+	ptrTrue         = true
+	ptrFalse        = false
+	memNval  uint32 = 1
+	memR     uint32 = 1
+	memW     uint32 = 1
+	// properties for memory-backed cache bucket
+	cacheProps = rpbc.RpbBucketProps{
+		Backend:       []byte("cache"), // this has to come from the riak.conf
+		NotfoundOk:    &ptrTrue,
+		AllowMult:     &ptrFalse,
+		LastWriteWins: &ptrFalse,
+		BasicQuorum:   &ptrFalse,
+		NVal:          &memNval,
+		R:             &memR,
+		W:             &memW,
+	}
+)
+
+// MakeCache makes a memory-backed bucket. You
+// must have the "multi"-backend option enabled
+// in your configuration in order for this to
+// work.
+func (b *Bucket) MakeCache() error {
+	return b.SetProperties(&cacheProps)
+
+}
+
 // Reset resets the bucket's properties
 func (b *Bucket) Reset() error {
 	req := &rpbc.RpbResetBucketReq{

--- a/bucket.go
+++ b/bucket.go
@@ -95,6 +95,11 @@ var (
 //   multi_backend.std.storage_backend = <leveldb OR bitcask>
 //   multi_backend.default = std
 //
+// MakeCache will error if your configuration is incorrect.
+//
+// NB: keep in mind that this bucket will only be backed by RAM and
+// uses no replication. This bucket should only be used to store
+// ephemeral objects.
 func (b *Bucket) MakeCache() error {
 	return b.SetProperties(&cacheProps)
 

--- a/bucket.go
+++ b/bucket.go
@@ -102,7 +102,6 @@ var (
 // ephemeral objects.
 func (b *Bucket) MakeCache() error {
 	return b.SetProperties(&cacheProps)
-
 }
 
 // Reset resets the bucket's properties

--- a/bucket.go
+++ b/bucket.go
@@ -81,10 +81,20 @@ var (
 	}
 )
 
-// MakeCache makes a memory-backed bucket. You
-// must have the "multi"-backend option enabled
-// in your configuration in order for this to
-// work.
+// MakeCache makes a memory-backed cache bucket. You will
+// most likely need the following options enabled in your riak.conf:
+//
+//   # this enables multiple backends
+//   storage_backend = multi
+//
+//   # this creates a backend called 'cache' backed by RAM
+//   multi_backend.cache.storage_backend = memory
+//
+//   # this makes a backend called 'std' and sets its storage backend
+//   # (you can name this one whatever you would like)
+//   multi_backend.std.storage_backend = <leveldb OR bitcask>
+//   multi_backend.default = std
+//
 func (b *Bucket) MakeCache() error {
 	return b.SetProperties(&cacheProps)
 

--- a/bucket_type_test.go
+++ b/bucket_type_test.go
@@ -3,6 +3,7 @@
 package rkive
 
 import (
+	"bytes"
 	check "gopkg.in/check.v1"
 )
 
@@ -10,9 +11,20 @@ func (s *riakSuite) TestGetBucketTypeProperties(c *check.C) {
 	c.Skip("not implemented")
 }
 
-func (s *riakSuite) TestMakeCache(c *check.C) {
-	err := s.cl.Bucket("test-cache").MakeCache()
+func (s *riakSuite) TestCache(c *check.C) {
+	cache := s.cl.Bucket("test-cache")
+
+	err := cache.MakeCache()
 	if err != nil {
 		c.Fatal(err)
 	}
+
+	props, err := cache.GetProperties()
+	if err != nil {
+		c.Error(err)
+	}
+	if !bytes.Equal(props.GetBackend(), []byte("cache")) {
+		c.Errorf("Expected backend %q; got %q", "cache", props.GetBackend())
+	}
+
 }

--- a/bucket_type_test.go
+++ b/bucket_type_test.go
@@ -9,3 +9,10 @@ import (
 func (s *riakSuite) TestGetBucketTypeProperties(c *check.C) {
 	c.Skip("not implemented")
 }
+
+func (s *riakSuite) TestMakeCache(c *check.C) {
+	err := s.cl.Bucket("test-cache").MakeCache()
+	if err != nil {
+		c.Fatal(err)
+	}
+}

--- a/bucket_type_test.go
+++ b/bucket_type_test.go
@@ -13,12 +13,10 @@ func (s *riakSuite) TestGetBucketTypeProperties(c *check.C) {
 
 func (s *riakSuite) TestCache(c *check.C) {
 	cache := s.cl.Bucket("test-cache")
-
 	err := cache.MakeCache()
 	if err != nil {
 		c.Fatal(err)
 	}
-
 	props, err := cache.GetProperties()
 	if err != nil {
 		c.Error(err)


### PR DESCRIPTION
This PR adds the `Bucket.MakeCache` method, which creates a RAM-backed bucket. In the future, we may be able to use this to cache query responses, etc. Tests included.
